### PR TITLE
Fix typo in folder name in DAL.csproj

### DIFF
--- a/CoreGymBookingSystem/DAL/DAL.csproj
+++ b/CoreGymBookingSystem/DAL/DAL.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Entitites\" />
+    <Folder Include="Entities\" />
     <Folder Include="Models\" />
   </ItemGroup>
 


### PR DESCRIPTION
Corrected the folder name from "Entitites" to "Entities" in the DAL.csproj file under the <ItemGroup> section. This change ensures proper referencing and organization of project directories.