### PR TITLE
Fixed issue where there were 2 connection strings.

### DIFF
--- a/CoreGymBookingSystem/MainApp/appsettings.json
+++ b/CoreGymBookingSystem/MainApp/appsettings.json
@@ -1,7 +1,6 @@
 {
   "ConnectionStrings": {
     "DefaultConnection": "Server=localhost;Database=CoreGymDB;Trusted_Connection=True;TrustServerCertificate=true;MultipleActiveResultSets=true",
-    "ApplicationDbContextConnection": "Server=(localdb)\\mssqllocaldb;Database=MainApp;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Problem: 
<img width="956" height="247" alt="image" src="https://github.com/user-attachments/assets/b36dd9e4-ad68-4fa0-909d-c88b5d4a1923" />

I Removed the ""ApplicationDbContextConnection"
Now we have only one "DefaultConnection"